### PR TITLE
修复事件反序列化错误

### DIFF
--- a/src/commonMain/kotlin/com/github/nyayurn/yutori/Event.kt
+++ b/src/commonMain/kotlin/com/github/nyayurn/yutori/Event.kt
@@ -48,7 +48,7 @@ open class Event(
     operator: User? = null,
     role: GuildRole? = null,
     user: User? = null,
-    vararg pair: Pair<String, Any?>
+    vararg pair: Pair<String, Any?> = arrayOf(),
 ) : Signaling.Body {
     val properties = mutableMapOf(
         "id" to id,


### PR DESCRIPTION
`com.github.nyayurn.yutori.Event` 的 `pair` 需要给到一个默认值否则反序列化为空时会抛异常，因为该参数非空

ps: 我对multiplatform并不熟，可以的话希望也能加入一下junit之类的测试依赖